### PR TITLE
W-10811351: Update DW version to latest 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <revision>0.1.6-SNAPSHOT</revision>
-        <data.weave.version>2.4.0-20220221</data.weave.version>
+        <data.weave.version>2.4.0-20220314</data.weave.version>
         <data.weave.testing.framework.version>1.1.0</data.weave.testing.framework.version>
         <data.weave.maven.plugin.version>0.1.0</data.weave.maven.plugin.version>
         <exchange.orgId>dummy-org-id</exchange.orgId>


### PR DESCRIPTION
Updated to 2.4.0-20220314 that is the one that generates the default pom of the DW extension